### PR TITLE
Pull Request for #27: Add requirements.do?

### DIFF
--- a/source/lib/requirements.do
+++ b/source/lib/requirements.do
@@ -1,2 +1,3 @@
 net from https://raw.githubusercontent.com/gslab-econ/gslab_stata/master/gslab_misc/ado       
 net install preliminaries, replace
+


### PR DESCRIPTION
Please review the changes here fix the issue that if `preliminaries` is not installed, the Stata example would not run.