### PR TITLE
Pull Request for #55: Add and refine unit tests for autofill functions

### DIFF
--- a/source/lib/JMSLab/autofill.py
+++ b/source/lib/JMSLab/autofill.py
@@ -19,7 +19,7 @@ def Autofill(var, format = "{}", namespace = None):
     return newcommand.format(commandname, content)
 
 def GenerateAutofillMacros(autofill_lists, autofill_formats = "{:.2f}", autofill_outfile = "autofill.tex"):
-    """
+    '''
 
     Parameters
     ----------
@@ -31,7 +31,7 @@ def GenerateAutofillMacros(autofill_lists, autofill_formats = "{:.2f}", autofill
     -------
     .tex file
 
-    """
+    '''
     if type(autofill_lists) != list:
             raise Exception("Argument 'autofill_lists' must be list")
             

--- a/source/lib/JMSLab/autofill.py
+++ b/source/lib/JMSLab/autofill.py
@@ -10,7 +10,7 @@ def Autofill(var, format = "{}", namespace = None):
             parent = parent.f_back
         
         if var not in parent.f_locals.keys() or parent is None:
-            raise Warning(f"Autofill: Variable '{var}' not found")
+            raise Exception(f"Autofill: Variable '{var}' not found")
         
         namespace = parent.f_locals
     

--- a/source/lib/JMSLab/autofill.py
+++ b/source/lib/JMSLab/autofill.py
@@ -37,8 +37,8 @@ def GenerateAutofillMacros(autofill_lists, autofill_formats = "{:.2f}", autofill
             
     nested_list = any(isinstance(i, list) for i in autofill_lists)
 
-    if (nested_list == True and type(autofill_formats) == str) or (nested_list == False 
-                                                                    and type(autofill_formats) == list):
+    if ((nested_list and type(autofill_formats) is str) 
+        or (nested_list and type(autofill_formats) is list)):
         raise Exception("Arguments 'autofill_lists' and 'autofill_formats' are incompatible")
 
     autofill_file = open(autofill_outfile, 'w')

--- a/source/lib/JMSLab/autofill.py
+++ b/source/lib/JMSLab/autofill.py
@@ -2,7 +2,7 @@ import inspect
 
 def Autofill(var, format = "{}", namespace = None):
     newcommand = f"\\newcommand{{{{\\{{}}}}}}{{{{{format}}}}}\n"
-    
+
     # Look for var in parent frames
     if namespace is None:
         parent = inspect.currentframe().f_back
@@ -13,14 +13,14 @@ def Autofill(var, format = "{}", namespace = None):
             raise Exception(f"Autofill: Variable '{var}' not found")
         
         namespace = parent.f_locals
-    
+
     commandname, content = var, namespace[var]
-    
+
     return newcommand.format(commandname, content)
 
 def GenerateAutofillMacros(autofill_lists,  autofill_outfile, autofill_formats = "{:.2f}"):
     """
-    
+
     Parameters
     ----------
     autofill_lists : TYPE - list
@@ -36,13 +36,13 @@ def GenerateAutofillMacros(autofill_lists,  autofill_outfile, autofill_formats =
             raise Exception("Argument 'autofill_lists' must be list")
             
     nested_list = any(isinstance(i, list) for i in autofill_lists)
-    
+
     if (nested_list == True and type(autofill_formats) == str) or (nested_list == False 
-                                                                   and type(autofill_formats) == list):
+                                                                    and type(autofill_formats) == list):
         raise Exception("Arguments 'autofill_lists' and 'autofill_formats' are incompatible")
-            
+
     autofill_file = open(autofill_outfile, 'w')
-    
+
     if type(autofill_formats) == str:
         output_macros = ''.join(Autofill(autofill_var, autofill_formats) for autofill_var in autofill_lists)
     else:

--- a/source/lib/JMSLab/autofill.py
+++ b/source/lib/JMSLab/autofill.py
@@ -38,7 +38,7 @@ def GenerateAutofillMacros(autofill_lists, autofill_formats = "{:.2f}", autofill
     nested_list = any(isinstance(i, list) for i in autofill_lists)
 
     if ((nested_list and type(autofill_formats) is str) 
-        or (nested_list and type(autofill_formats) is list)):
+        or (not nested_list and type(autofill_formats) is list)):
         raise Exception("Arguments 'autofill_lists' and 'autofill_formats' are incompatible")
 
     autofill_file = open(autofill_outfile, 'w')

--- a/source/lib/JMSLab/autofill.py
+++ b/source/lib/JMSLab/autofill.py
@@ -18,7 +18,7 @@ def Autofill(var, format = "{}", namespace = None):
 
     return newcommand.format(commandname, content)
 
-def GenerateAutofillMacros(autofill_lists,  autofill_outfile, autofill_formats = "{:.2f}"):
+def GenerateAutofillMacros(autofill_lists, autofill_formats = "{:.2f}", autofill_outfile = "autofill.tex"):
     """
 
     Parameters

--- a/source/lib/JMSLab/autofill.py
+++ b/source/lib/JMSLab/autofill.py
@@ -18,7 +18,7 @@ def Autofill(var, format = "{}", namespace = None):
     
     return newcommand.format(commandname, content)
 
-def GenerateAutofillMacros(autofill_lists,  autofill_formats, autofill_outfile):
+def GenerateAutofillMacros(autofill_lists,  autofill_outfile, autofill_formats = "{:.2f}"):
     """
     
     Parameters

--- a/source/lib/JMSLab/autofill.py
+++ b/source/lib/JMSLab/autofill.py
@@ -32,6 +32,15 @@ def GenerateAutofillMacros(autofill_lists,  autofill_outfile, autofill_formats =
     .tex file
 
     """
+    if type(autofill_lists) != list:
+            raise Exception("Argument 'autofill_lists' must be list")
+            
+    nested_list = any(isinstance(i, list) for i in autofill_lists)
+    
+    if (nested_list == True and type(autofill_formats) == str) or (nested_list == False 
+                                                                   and type(autofill_formats) == list):
+        raise Exception("Arguments 'autofill_lists' and 'autofill_formats' are incompatible")
+            
     autofill_file = open(autofill_outfile, 'w')
     
     if type(autofill_formats) == str:

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -5,54 +5,54 @@ from os.path import exists
 from ..autofill import GenerateAutofillMacros
 
 class Test(TestCase):
-    
+
     def setUp(self):
         self.tempdir = tempfile.mkdtemp() 
         self.outfile = self.tempdir + r"output_macros.tex"
         return
-    
+
     def tearDown(self):
         shutil.rmtree(self.tempdir)
         return
-    
+
     def test_file_exists(self):
         Epsilon = -1.19
         
         GenerateAutofillMacros(["Epsilon"], self.outfile)
         self.assertTrue(exists(self.outfile))
         return
-    
+
     def test_exception(self):
         with self.assertRaises(Exception) as context:
             GenerateAutofillMacros(["Epsilon"], self.outfile)
 
         self.assertTrue("Autofill: Variable 'Epsilon' not found" in str(context.exception))
         return
-    
+
     def test_output(self):
         Epsilon = - 1.19
-       
+        
         GenerateAutofillMacros(["Epsilon"], self.outfile)
         tex_file = open(self.outfile, 'r')
         content = tex_file.read()
         self.assertEqual(content, "\\newcommand{\\Epsilon}{-1.19}\n")
         tex_file.close()
         return
-    
+
     def test_list_format(self):
         Epsilon = - 1.19
         MarginalCost = 2.59
-            
+
         with self.assertRaises(Exception) as context:
             GenerateAutofillMacros("Epsilon", self.outfile)
 
         self.assertTrue("Argument 'autofill_lists' must be list" in str(context.exception))
-            
+
         with self.assertRaises(Exception) as context:
             GenerateAutofillMacros(["Epsilon"], self.outfile, ["{:.2f}", "\\textnormal{{{:.2f}}}"])
 
         self.assertTrue("Arguments 'autofill_lists' and 'autofill_formats' are incompatible" in str(context.exception))
-            
+
         with self.assertRaises(Exception) as context:
             GenerateAutofillMacros([["Epsilon"], ["Marginal Cost"]], self.outfile)
 

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -1,64 +1,60 @@
 from unittest import main, TestCase
 from ..autofill import GenerateAutofillMacros
 from os.path import exists
-import tempfile
+import tempfile, shutil 
 
 class Test(TestCase):
     
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp() 
+        self.outfile = self.tempdir + r"output_macros.tex"
+    
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+    
     def test_file_exists(self):
-        
         Epsilon = - 1.19
         MarginalCost = (1 + 1 / Epsilon) * 16.22
-        with tempfile.TemporaryDirectory() as tempdir:
-     
-            autofill_outfile = tempdir + r"output_macros.tex"
         
-            GenerateAutofillMacros(["Epsilon", "MarginalCost"], autofill_outfile)
-            self.assertTrue(exists(autofill_outfile))
+        GenerateAutofillMacros(["Epsilon", "MarginalCost"], self.outfile)
+        self.assertTrue(exists(self.outfile))
         return
     
     def test_exception(self):
-        with tempfile.TemporaryDirectory() as tempdir:
-            autofill_outfile = tempdir + r"output_macros.tex"
-            with self.assertRaises(Exception) as context:
-                GenerateAutofillMacros(["Epsilon"], autofill_outfile)
+        with self.assertRaises(Exception) as context:
+            GenerateAutofillMacros(["Epsilon"], self.outfile)
 
-            self.assertTrue("Autofill: Variable 'Epsilon' not found" in str(context.exception))
+        self.assertTrue("Autofill: Variable 'Epsilon' not found" in str(context.exception))
         return
     
     def test_output(self):
         Epsilon = - 1.19
-        with tempfile.TemporaryDirectory() as tempdir:
-            autofill_outfile = tempdir + r"output_macros.tex"
-        
-            GenerateAutofillMacros(["Epsilon"], autofill_outfile)
-            tex_file = open(autofill_outfile, 'r')
-            content = tex_file.read()
-            self.assertEqual(content, "\\newcommand{\\Epsilon}{-1.19}\n")
+       
+        GenerateAutofillMacros(["Epsilon"], self.outfile)
+        tex_file = open(self.outfile, 'r')
+        content = tex_file.read()
+        self.assertEqual(content, "\\newcommand{\\Epsilon}{-1.19}\n")
         return
     
     def test_list_format(self):
         Epsilon = - 1.19
         MarginalCost = (1 + 1 / Epsilon) * 16.22
-        with tempfile.TemporaryDirectory() as tempdir:
-     
-            autofill_outfile = tempdir + r"output_macros.tex"
             
-            with self.assertRaises(Exception) as context:
-                GenerateAutofillMacros("Epsilon", autofill_outfile)
+        with self.assertRaises(Exception) as context:
+            GenerateAutofillMacros("Epsilon", self.outfile)
 
-            self.assertTrue("Argument 'autofill_lists' must be list" in str(context.exception))
+        self.assertTrue("Argument 'autofill_lists' must be list" in str(context.exception))
             
-            with self.assertRaises(Exception) as context:
-                GenerateAutofillMacros(["Epsilon"], autofill_outfile, ["{:.2f}", "\\textnormal{{{:.2f}}}"])
+        with self.assertRaises(Exception) as context:
+            GenerateAutofillMacros(["Epsilon"], self.outfile, ["{:.2f}", "\\textnormal{{{:.2f}}}"])
 
-            self.assertTrue("Arguments 'autofill_lists' and 'autofill_formats' are incompatible" in str(context.exception))
+        self.assertTrue("Arguments 'autofill_lists' and 'autofill_formats' are incompatible" in str(context.exception))
             
-            with self.assertRaises(Exception) as context:
-                GenerateAutofillMacros([["Epsilon"], ["Marginal Cost"]], autofill_outfile)
+        with self.assertRaises(Exception) as context:
+            GenerateAutofillMacros([["Epsilon"], ["Marginal Cost"]], self.outfile)
 
-            self.assertTrue("Arguments 'autofill_lists' and 'autofill_formats' are incompatible" in str(context.exception))
-            return
+        self.assertTrue("Arguments 'autofill_lists' and 'autofill_formats' are incompatible" in str(context.exception))
+        return
         
 if __name__ == '__main__':
     main()

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -59,7 +59,7 @@ class Test(TestCase):
         self.assertTrue("Arguments 'autofill_lists' and 'autofill_formats' are incompatible" in str(context.exception))
 
         with self.assertRaises(Exception) as context:
-            GenerateAutofillMacros([["Epsilon"], ["Marginal Cost"]], autofill_outfile = self.outfile)
+            GenerateAutofillMacros([["Epsilon"], ["MarginalCost"]], autofill_outfile = self.outfile)
 
         self.assertTrue("Arguments 'autofill_lists' and 'autofill_formats' are incompatible" in str(context.exception))
         return None

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -17,7 +17,7 @@ class Test(TestCase):
         MarginalCost = (1 + 1 / Epsilon) * P_94
         autofill_outfile = r"output_macros.tex"
         
-        GenerateAutofillMacros(["Epsilon", "MarginalCost"], "{:.2f}", autofill_outfile)
+        GenerateAutofillMacros(["Epsilon", "MarginalCost"], autofill_outfile)
         self.assertTrue(exists(autofill_outfile))
         return
     
@@ -25,7 +25,7 @@ class Test(TestCase):
         
         autofill_outfile = r"output_macros.tex"
         with self.assertRaises(Exception) as context:
-            GenerateAutofillMacros(["Epsilon"], "{:.2f}", autofill_outfile)
+            GenerateAutofillMacros(["Epsilon"], autofill_outfile)
 
         self.assertTrue("Autofill: Variable 'Epsilon' not found" in str(context.exception))
         return

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -9,6 +9,7 @@ from os.path import exists
 
 
 class Test(TestCase):
+    
     def test_file_exists(self):
         
         P_94 = 16.22
@@ -18,6 +19,15 @@ class Test(TestCase):
         
         GenerateAutofillMacros(["Epsilon", "MarginalCost"], "{:.2f}", autofill_outfile)
         self.assertTrue(exists(autofill_outfile))
+        return
+    
+    def test_exception(self):
+        
+        autofill_outfile = r"output_macros.tex"
+        with self.assertRaises(Exception) as context:
+            GenerateAutofillMacros(["Epsilon"], "{:.2f}", autofill_outfile)
+
+        self.assertTrue("Autofill: Variable 'Epsilon' not found" in str(context.exception))
         return
 
 if __name__ == '__main__':

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -1,22 +1,24 @@
 from unittest import main, TestCase
-from ..autofill import GenerateAutofillMacros
-from os.path import exists
 import tempfile, shutil 
+from os.path import exists
+
+from ..autofill import GenerateAutofillMacros
 
 class Test(TestCase):
     
     def setUp(self):
         self.tempdir = tempfile.mkdtemp() 
         self.outfile = self.tempdir + r"output_macros.tex"
+        return
     
     def tearDown(self):
         shutil.rmtree(self.tempdir)
+        return
     
     def test_file_exists(self):
-        Epsilon = - 1.19
-        MarginalCost = (1 + 1 / Epsilon) * 16.22
+        Epsilon = -1.19
         
-        GenerateAutofillMacros(["Epsilon", "MarginalCost"], self.outfile)
+        GenerateAutofillMacros(["Epsilon"], self.outfile)
         self.assertTrue(exists(self.outfile))
         return
     
@@ -39,7 +41,7 @@ class Test(TestCase):
     
     def test_list_format(self):
         Epsilon = - 1.19
-        MarginalCost = (1 + 1 / Epsilon) * 16.22
+        MarginalCost = 2.59
             
         with self.assertRaises(Exception) as context:
             GenerateAutofillMacros("Epsilon", self.outfile)

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -34,6 +34,7 @@ class Test(TestCase):
         tex_file = open(self.outfile, 'r')
         content = tex_file.read()
         self.assertEqual(content, "\\newcommand{\\Epsilon}{-1.19}\n")
+        tex_file.close()
         return
     
     def test_list_format(self):

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -41,7 +41,7 @@ class Test(TestCase):
             tex_file = open(autofill_outfile, 'r')
             content = tex_file.read()
             self.assertEqual(content, "\\newcommand{\\Epsilon}{-1.19}\n")
-        
+        return
 
 if __name__ == '__main__':
     main()

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -32,11 +32,14 @@ class Test(TestCase):
 
     def test_output(self):
         Epsilon = - 1.19
+        MarginalCost = 2.59
         
-        GenerateAutofillMacros(["Epsilon"], autofill_outfile = self.outfile)
+        GenerateAutofillMacros([["Epsilon"], ["MarginalCost"]], 
+                               autofill_formats = ["{:.2f}", "\\textnormal{{{:.2f}}}"], 
+                               autofill_outfile = self.outfile)
         tex_file = open(self.outfile, 'r')
         content = tex_file.read()
-        self.assertEqual(content, "\\newcommand{\\Epsilon}{-1.19}\n")
+        self.assertEqual(content, "\\newcommand{\\Epsilon}{-1.19}\n\\newcommand{\\MarginalCost}{\\textnormal{2.59}}\n")
         tex_file.close()
         return None
 

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -5,6 +5,7 @@ sys.path.append('./source/lib')
 from unittest import main, TestCase
 from JMSLab.autofill import GenerateAutofillMacros
 from os.path import exists
+import tempfile
 
 
 
@@ -12,23 +13,35 @@ class Test(TestCase):
     
     def test_file_exists(self):
         
-        P_94 = 16.22
         Epsilon = - 1.19
-        MarginalCost = (1 + 1 / Epsilon) * P_94
-        autofill_outfile = r"output_macros.tex"
+        MarginalCost = (1 + 1 / Epsilon) * 16.22
+        with tempfile.TemporaryDirectory() as tempdir:
+     
+            autofill_outfile = tempdir + r"output_macros.tex"
         
-        GenerateAutofillMacros(["Epsilon", "MarginalCost"], autofill_outfile)
-        self.assertTrue(exists(autofill_outfile))
+            GenerateAutofillMacros(["Epsilon", "MarginalCost"], autofill_outfile)
+            self.assertTrue(exists(autofill_outfile))
         return
     
     def test_exception(self):
-        
-        autofill_outfile = r"output_macros.tex"
-        with self.assertRaises(Exception) as context:
-            GenerateAutofillMacros(["Epsilon"], autofill_outfile)
+        with tempfile.TemporaryDirectory() as tempdir:
+            autofill_outfile = tempdir + r"output_macros.tex"
+            with self.assertRaises(Exception) as context:
+                GenerateAutofillMacros(["Epsilon"], autofill_outfile)
 
-        self.assertTrue("Autofill: Variable 'Epsilon' not found" in str(context.exception))
+            self.assertTrue("Autofill: Variable 'Epsilon' not found" in str(context.exception))
         return
+    
+    def test_output(self):
+        Epsilon = - 1.19
+        with tempfile.TemporaryDirectory() as tempdir:
+            autofill_outfile = tempdir + r"output_macros.tex"
+        
+            GenerateAutofillMacros(["Epsilon"], autofill_outfile)
+            tex_file = open(autofill_outfile, 'r')
+            content = tex_file.read()
+            self.assertEqual(content, "\\newcommand{\\Epsilon}{-1.19}\n")
+        
 
 if __name__ == '__main__':
     main()

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -1,13 +1,7 @@
-import sys
-
-sys.path.append('./source/lib')
-
 from unittest import main, TestCase
-from JMSLab.autofill import GenerateAutofillMacros
+from ..autofill import GenerateAutofillMacros
 from os.path import exists
 import tempfile
-
-
 
 class Test(TestCase):
     

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -1,6 +1,7 @@
 from unittest import main, TestCase
-import tempfile, shutil 
 from os.path import exists
+
+import tempfile, shutil 
 
 from ..autofill import GenerateAutofillMacros
 

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -20,14 +20,14 @@ class Test(TestCase):
         
         GenerateAutofillMacros(["Epsilon"], autofill_outfile = self.outfile)
         self.assertTrue(exists(self.outfile))
-        return
+        return None
 
     def test_exception(self):
         with self.assertRaises(Exception) as context:
             GenerateAutofillMacros(["Epsilon"], autofill_outfile =  self.outfile)
 
         self.assertTrue("Autofill: Variable 'Epsilon' not found" in str(context.exception))
-        return
+        return None
 
     def test_output(self):
         Epsilon = - 1.19
@@ -37,7 +37,7 @@ class Test(TestCase):
         content = tex_file.read()
         self.assertEqual(content, "\\newcommand{\\Epsilon}{-1.19}\n")
         tex_file.close()
-        return
+        return None
 
     def test_list_format(self):
         Epsilon = - 1.19
@@ -58,7 +58,7 @@ class Test(TestCase):
             GenerateAutofillMacros([["Epsilon"], ["Marginal Cost"]], autofill_outfile = self.outfile)
 
         self.assertTrue("Arguments 'autofill_lists' and 'autofill_formats' are incompatible" in str(context.exception))
-        return
+        return None
         
 if __name__ == '__main__':
     main()

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -9,7 +9,7 @@ class Test(TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp() 
         self.outfile = self.tempdir + r"output_macros.tex"
-        return
+        return None
 
     def tearDown(self):
         shutil.rmtree(self.tempdir)

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -18,13 +18,13 @@ class Test(TestCase):
     def test_file_exists(self):
         Epsilon = -1.19
         
-        GenerateAutofillMacros(["Epsilon"], self.outfile)
+        GenerateAutofillMacros(["Epsilon"], autofill_outfile = self.outfile)
         self.assertTrue(exists(self.outfile))
         return
 
     def test_exception(self):
         with self.assertRaises(Exception) as context:
-            GenerateAutofillMacros(["Epsilon"], self.outfile)
+            GenerateAutofillMacros(["Epsilon"], autofill_outfile =  self.outfile)
 
         self.assertTrue("Autofill: Variable 'Epsilon' not found" in str(context.exception))
         return
@@ -32,7 +32,7 @@ class Test(TestCase):
     def test_output(self):
         Epsilon = - 1.19
         
-        GenerateAutofillMacros(["Epsilon"], self.outfile)
+        GenerateAutofillMacros(["Epsilon"], autofill_outfile = self.outfile)
         tex_file = open(self.outfile, 'r')
         content = tex_file.read()
         self.assertEqual(content, "\\newcommand{\\Epsilon}{-1.19}\n")
@@ -44,17 +44,18 @@ class Test(TestCase):
         MarginalCost = 2.59
 
         with self.assertRaises(Exception) as context:
-            GenerateAutofillMacros("Epsilon", self.outfile)
+            GenerateAutofillMacros("Epsilon", autofill_outfile = self.outfile)
 
         self.assertTrue("Argument 'autofill_lists' must be list" in str(context.exception))
 
         with self.assertRaises(Exception) as context:
-            GenerateAutofillMacros(["Epsilon"], self.outfile, ["{:.2f}", "\\textnormal{{{:.2f}}}"])
+            GenerateAutofillMacros(["Epsilon"], autofill_formats = ["{:.2f}", "\\textnormal{{{:.2f}}}"], 
+                                   autofill_outfile = self.outfile)
 
         self.assertTrue("Arguments 'autofill_lists' and 'autofill_formats' are incompatible" in str(context.exception))
 
         with self.assertRaises(Exception) as context:
-            GenerateAutofillMacros([["Epsilon"], ["Marginal Cost"]], self.outfile)
+            GenerateAutofillMacros([["Epsilon"], ["Marginal Cost"]], autofill_outfile = self.outfile)
 
         self.assertTrue("Arguments 'autofill_lists' and 'autofill_formats' are incompatible" in str(context.exception))
         return

--- a/source/lib/JMSLab/tests/test_autofill.py
+++ b/source/lib/JMSLab/tests/test_autofill.py
@@ -42,7 +42,30 @@ class Test(TestCase):
             content = tex_file.read()
             self.assertEqual(content, "\\newcommand{\\Epsilon}{-1.19}\n")
         return
+    
+    def test_list_format(self):
+        Epsilon = - 1.19
+        MarginalCost = (1 + 1 / Epsilon) * 16.22
+        with tempfile.TemporaryDirectory() as tempdir:
+     
+            autofill_outfile = tempdir + r"output_macros.tex"
+            
+            with self.assertRaises(Exception) as context:
+                GenerateAutofillMacros("Epsilon", autofill_outfile)
 
+            self.assertTrue("Argument 'autofill_lists' must be list" in str(context.exception))
+            
+            with self.assertRaises(Exception) as context:
+                GenerateAutofillMacros(["Epsilon"], autofill_outfile, ["{:.2f}", "\\textnormal{{{:.2f}}}"])
+
+            self.assertTrue("Arguments 'autofill_lists' and 'autofill_formats' are incompatible" in str(context.exception))
+            
+            with self.assertRaises(Exception) as context:
+                GenerateAutofillMacros([["Epsilon"], ["Marginal Cost"]], autofill_outfile)
+
+            self.assertTrue("Arguments 'autofill_lists' and 'autofill_formats' are incompatible" in str(context.exception))
+            return
+        
 if __name__ == '__main__':
     main()
 


### PR DESCRIPTION
@santiagohermo significant changes here are contained in `source/lib/JMSLab/tests/test_autofill.py` where we added 3 additional tests on top of checking for out file existence (as per this [list](https://github.com/JMSLab/Template/issues/55#issue-1181188969)).

Also added default format for autofill wrapper in `source/lib/JMSLab/autofill.py`.

Thanks!