### PR TITLE
#177 fix gap in exception path for dag checker

### DIFF
--- a/.github/checks/check_sconscripts.py
+++ b/.github/checks/check_sconscripts.py
@@ -79,7 +79,8 @@ def CollectProblems():
                 missing_dirs.append(subdir_path)
                 continue
             for f in subfiles:
-                if not IsMentioned(content, f, subdir_path):
+                subpath = f"source/{rel}/{subdir}/{f}"
+                if not IsExcludedFile(subpath) and not IsMentioned(content, f, subdir_path):
                     missing_mentions.append(f"{dir_path} -> {subdir}/{f}")
     return missing_dirs, missing_mentions
 

--- a/.github/checks/check_sconscripts.py
+++ b/.github/checks/check_sconscripts.py
@@ -81,7 +81,23 @@ def CollectProblems():
             for f in subfiles:
                 subpath = f"source/{rel}/{subdir}/{f}"
                 if not IsExcludedFile(subpath) and not IsMentioned(content, f, subdir_path):
-                    missing_mentions.append(f"{dir_path} -> {subdir}/{f}")
+        for subdir in list(dir_names):
+            subdir_path = dir_path / subdir
+            if HasLocalSConscript(subdir_path) and re.search(rf"\b{re.escape(subdir)}\b", content):
+                continue
+            for nested_dir_path, nested_dir_names, nested_file_names in os.walk(subdir_path):
+                nested_dir_path = Path(nested_dir_path)
+                nested_dir_names[:] = sorted(d for d in nested_dir_names if not IsIgnored(d))
+                nested_files = sorted(
+                    f for f in nested_file_names
+                    if not IsIgnored(f) and ShouldCheck(nested_dir_path, f)
+                )
+                for f in nested_files:
+                    nested_path = f"source/{nested_dir_path.relative_to(ROOT).as_posix()}/{f}"
+                    if not IsExcludedFile(nested_path) and not IsMentioned(content, f, nested_dir_path):
+                        missing_mentions.append(f"{dir_path} -> {nested_dir_path.relative_to(dir_path).as_posix()}/{f}")
+            if not HasLocalSConscript(subdir_path):
+                dir_names.remove(subdir)
     return missing_dirs, missing_mentions
 
 

--- a/.github/checks/check_sconscripts.py
+++ b/.github/checks/check_sconscripts.py
@@ -66,27 +66,15 @@ def CollectProblems():
             path = f"source/{rel}/{f}"
             if ShouldCheck(dir_path, f) and not IsExcludedFile(path) and not IsMentioned(content, f, dir_path):
                 missing_mentions.append(f"{dir_path} -> {f}")
-        for subdir in dir_names:
-            subdir_path = dir_path / subdir
-            if HasLocalSConscript(subdir_path) and re.search(rf"\b{re.escape(subdir)}\b", content):
-                continue
-            try:
-                subfiles = sorted(
-                    e for e in os.listdir(subdir_path)
-                    if not IsIgnored(e) and (subdir_path / e).is_file() and ShouldCheck(subdir_path, e)
-                )
-            except Exception:
-                missing_dirs.append(subdir_path)
-                continue
-            for f in subfiles:
-                subpath = f"source/{rel}/{subdir}/{f}"
-                if not IsExcludedFile(subpath) and not IsMentioned(content, f, subdir_path):
         for subdir in list(dir_names):
             subdir_path = dir_path / subdir
             if HasLocalSConscript(subdir_path) and re.search(rf"\b{re.escape(subdir)}\b", content):
                 continue
             for nested_dir_path, nested_dir_names, nested_file_names in os.walk(subdir_path):
                 nested_dir_path = Path(nested_dir_path)
+                if nested_dir_path != subdir_path and HasLocalSConscript(nested_dir_path):
+                    nested_dir_names[:] = []
+                    continue
                 nested_dir_names[:] = sorted(d for d in nested_dir_names if not IsIgnored(d))
                 nested_files = sorted(
                     f for f in nested_file_names

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The repository is prebuilt with some automated testing using [Github Actions](./
 
 To run all tests, add `[run-actions-all]` to a commit message or type `/run-actions-all` in a comment.
 
-To run a particular test, type `/run-actions-NAMEOFTEST` in a comment (e.g., `/run-actions-log` to run [this test](./.github/checks/check_sconscript_log.py); see [commands](./.github/checks/checks.json) for others).
+To run a particular test, type `/run-actions-NAMEOFTEST` in a comment (e.g., `/run-actions-log` to run [this test](./.github/checks/check_log_failures.py); see [commands](./.github/checks/checks.json) for others).
 
 ### Citations and expectations for usage
 


### PR DESCRIPTION
In this issue, we modified .github/checks/check_sconscripts.py such that files inside a subdirectory that have no SConscript of their own but are referenced by name in their parent's SConscript consult the exceptions file.

[LLM Review](https://github.com/user-attachments/files/30599674/issue177_check_sconscripts_review.md); no revise comments given